### PR TITLE
Add CLI, transpile vectors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,17 @@
 .shadow-cljs
 node_modules
 web/resources/public/js
+
+# Clojure
+/target
+/classes
+/checkouts
+profiles.clj
+pom.xml
+pom.xml.asc
+*.jar
+*.class
+/.lein-*
+/.nrepl-port
+/.prepl-port
+/.cpcache

--- a/README.md
+++ b/README.md
@@ -14,6 +14,21 @@ There's also a tiny babashka CLI. The CLI can be installed with [bbin]:
 
 And used like this:
 
-     pi
+    $ cat source.clj
+    (defn foo [x & xs] xs)
+
+    (inc 2)
+
+    (map inc [1 2 3])
+    $ cat source.clj | clj2el --multiple
+    (defun foo (x &rest xs) xs)
+
+    (1+ 2)
+
+    (mapcar #'1+ (list 1 2 3))
+    $ cat source2.clj
+    [1 2 3]
+    $ cat source2.clj | clj2el
+    (list 1 2 3)
 
 [bbin]: https://github.com/babashka/bbin

--- a/README.md
+++ b/README.md
@@ -14,21 +14,23 @@ There's also a tiny babashka CLI. The CLI can be installed with [bbin]:
 
 And used like this:
 
+    $ ls
+    source.clj  source2.clj
     $ cat source.clj
     (defn foo [x & xs] xs)
 
     (inc 2)
 
     (map inc [1 2 3])
-    $ cat source.clj | clj2el --multiple
+    $ cat source.clj | clj2el
     (defun foo (x &rest xs) xs)
 
     (1+ 2)
 
-    (mapcar #'1+ (list 1 2 3))
+    (mapcar #'1+ (vector 1 2 3))
     $ cat source2.clj
     [1 2 3]
     $ cat source2.clj | clj2el
-    (list 1 2 3)
+    (vector 1 2 3)
 
 [bbin]: https://github.com/babashka/bbin

--- a/README.md
+++ b/README.md
@@ -5,3 +5,15 @@ but contributions are welcome. It is targeted at folks who know Clojure better
 than Emacs Lisp.
 
 See the interactive web page [here](https://borkdude.github.io/clj2el/).
+
+## CLI
+
+There's also a tiny babashka CLI. The CLI can be installed with [bbin]:
+
+    bbin install io.github.borkdude/clj2el
+
+And used like this:
+
+     pi
+
+[bbin]: https://github.com/babashka/bbin

--- a/bb.edn
+++ b/bb.edn
@@ -1,2 +1,2 @@
 {:deps {io.github.borkdude/clj2el {:local/root "."}}
- :bbin/bin {clj2el {:main-opts ["-m" "clj2el.exec/-main"]}}}
+ :bbin/bin {clj2el {:main-opts ["-x" "clj2el.exec/exec"]}}}

--- a/bb.edn
+++ b/bb.edn
@@ -1,2 +1,2 @@
 {:deps {io.github.borkdude/clj2el {:local/root "."}}
- :bbin/bin {clj2el {:main-opts ["-m" "clj2el.cli/-main"]}}}
+ :bbin/bin {clj2el {:main-opts ["-m" "clj2el.exec/-main"]}}}

--- a/bb.edn
+++ b/bb.edn
@@ -1,0 +1,2 @@
+{:deps {io.github.borkdude/clj2el {:local/root "."}}
+ :bbin/bin {clj2el {:main-opts ["-m" "clj2el.cli/-main"]}}}

--- a/deps.edn
+++ b/deps.edn
@@ -1,1 +1,1 @@
-{:paths ["src"]}
+{:paths ["src"] :deps {borkdude/edamame {:mvn/version "1.3.20"}}}

--- a/src/clj2el/cli.clj
+++ b/src/clj2el/cli.clj
@@ -1,47 +1,18 @@
 (ns clj2el.cli
   (:require
    [clj2el.api :refer [clj2el]]
-   [clojure.edn :as edn]
    [clojure.pprint :refer [pprint]]
    [clojure.string :as str]
-   [edamame.core :as e]
-
-   ))
-
-(defn read-multiple-forms [s]
-  (edn/read-string (str "[" s "]")))
-
-(defn prn-str-multiple-forms [forms]
-  (str/join "\n" (map prn-str forms)))
-
-(defn pprint-str [form] (with-out-str (pprint form)))
+   [edamame.core :as e]))
 
 (defn pprint-str-multiple-forms [forms]
-  (str/join "\n" (map pprint-str forms)))
+  (str/join "\n" (map #(with-out-str (pprint %)) forms)))
 
-#_
-(pprint (e/parse-string-all "(f) (g) (h)" {:all true}))
-
-(defn by-reinventing-edamame [args]
-  (let [argset (set args)
-        multiple? (contains? argset "--multiple") ;; assuming we don't want to depend on babashka.cli
-        pretty? (contains? argset "--pretty")
-        read-fn (if multiple? read-multiple-forms edn/read-string)
-        write-str-fn (cond (and multiple? pretty?) pprint-str-multiple-forms
-                           (and multiple? (not pretty?)) prn-str-multiple-forms
-                           (and (not multiple?) pretty?) pprint-str
-                           (and (not multiple?) (not pretty?)) prn-str)
-        clj2el-fn (if multiple? (partial map clj2el) clj2el)]
-    (-> *in* slurp read-fn clj2el-fn write-str-fn print)))
-
-(defn sanely [args]
-  ;; avoid --multiple and --pretty for now
+(defn sanely [_args]
   (let [read-str (fn [s] (e/parse-string-all s {:all true}))
         clj2el-fn (partial map clj2el)
         write-str pprint-str-multiple-forms]
     (-> *in* slurp read-str clj2el-fn write-str print)))
 
 (defn -main [& args]
-  (sanely args)
-  #_
-  (by-reinventing-edamame args))
+  (sanely args))

--- a/src/clj2el/cli.clj
+++ b/src/clj2el/cli.clj
@@ -8,11 +8,8 @@
 (defn pprint-str-multiple-forms [forms]
   (str/join "\n" (map #(with-out-str (pprint %)) forms)))
 
-(defn sanely [_args]
+(defn -main [& _args]
   (let [read-str (fn [s] (e/parse-string-all s {:all true}))
         clj2el-fn (partial map clj2el)
         write-str pprint-str-multiple-forms]
     (-> *in* slurp read-str clj2el-fn write-str print)))
-
-(defn -main [& args]
-  (sanely args))

--- a/src/clj2el/cli.clj
+++ b/src/clj2el/cli.clj
@@ -24,5 +24,6 @@
         write-str-fn (cond (and multiple? pretty?) pprint-str-multiple-forms
                            (and multiple? (not pretty?)) prn-str-multiple-forms
                            (and (not multiple?) pretty?) pprint-str
-                           (and (not multiple?) (not pretty?)) prn-str)]
-    (-> *in* slurp read-fn clj2el write-str-fn print)))
+                           (and (not multiple?) (not pretty?)) prn-str)
+        clj2el-fn (if multiple? (partial map clj2el) clj2el)]
+    (-> *in* slurp read-fn clj2el-fn write-str-fn print)))

--- a/src/clj2el/cli.clj
+++ b/src/clj2el/cli.clj
@@ -5,11 +5,12 @@
    [clojure.string :as str]
    [edamame.core :as e]))
 
-(defn pprint-str-multiple-forms [forms]
+(defn read-str-multiple [s]
+  (e/parse-string-all s {:all true}))
+
+(defn write-str-multiple [forms]
   (str/join "\n" (map #(with-out-str (pprint %)) forms)))
 
 (defn -main [& _args]
-  (let [read-str (fn [s] (e/parse-string-all s {:all true}))
-        clj2el-fn (partial map clj2el)
-        write-str pprint-str-multiple-forms]
-    (-> *in* slurp read-str clj2el-fn write-str print)))
+  (let [clj2el-fn (partial map clj2el)]
+    (-> *in* slurp read-str-multiple clj2el-fn write-str-multiple print)))

--- a/src/clj2el/cli.clj
+++ b/src/clj2el/cli.clj
@@ -3,7 +3,10 @@
    [clj2el.api :refer [clj2el]]
    [clojure.edn :as edn]
    [clojure.pprint :refer [pprint]]
-   [clojure.string :as str]))
+   [clojure.string :as str]
+   [edamame.core :as e]
+
+   ))
 
 (defn read-multiple-forms [s]
   (edn/read-string (str "[" s "]")))
@@ -16,7 +19,10 @@
 (defn pprint-str-multiple-forms [forms]
   (str/join "\n" (map pprint-str forms)))
 
-(defn -main [& args]
+#_
+(pprint (e/parse-string-all "(f) (g) (h)" {:all true}))
+
+(defn by-reinventing-edamame [args]
   (let [argset (set args)
         multiple? (contains? argset "--multiple") ;; assuming we don't want to depend on babashka.cli
         pretty? (contains? argset "--pretty")
@@ -27,3 +33,15 @@
                            (and (not multiple?) (not pretty?)) prn-str)
         clj2el-fn (if multiple? (partial map clj2el) clj2el)]
     (-> *in* slurp read-fn clj2el-fn write-str-fn print)))
+
+(defn sanely [args]
+  ;; avoid --multiple and --pretty for now
+  (let [read-str (fn [s] (e/parse-string-all s {:all true}))
+        clj2el-fn (partial map clj2el)
+        write-str pprint-str-multiple-forms]
+    (-> *in* slurp read-str clj2el-fn write-str print)))
+
+(defn -main [& args]
+  (sanely args)
+  #_
+  (by-reinventing-edamame args))

--- a/src/clj2el/cli.clj
+++ b/src/clj2el/cli.clj
@@ -12,5 +12,4 @@
   (str/join "\n" (map #(with-out-str (pprint %)) forms)))
 
 (defn -main [& _args]
-  (let [clj2el-fn (partial map clj2el)]
-    (-> *in* slurp read-str-multiple clj2el-fn write-str-multiple print)))
+  (->> *in* slurp read-str-multiple (map clj2el) write-str-multiple print))

--- a/src/clj2el/cli.clj
+++ b/src/clj2el/cli.clj
@@ -1,0 +1,28 @@
+(ns clj2el.cli
+  (:require
+   [clj2el.api :refer [clj2el]]
+   [clojure.edn :as edn]
+   [clojure.pprint :refer [pprint]]
+   [clojure.string :as str]))
+
+(defn read-multiple-forms [s]
+  (edn/read-string (str "[" s "]")))
+
+(defn prn-str-multiple-forms [forms]
+  (str/join "\n" (map prn-str forms)))
+
+(defn pprint-str [form] (with-out-str (pprint form)))
+
+(defn pprint-str-multiple-forms [forms]
+  (str/join "\n" (map pprint-str forms)))
+
+(defn -main [& args]
+  (let [argset (set args)
+        multiple? (contains? argset "--multiple") ;; assuming we don't want to depend on babashka.cli
+        pretty? (contains? argset "--pretty")
+        read-fn (if multiple? read-multiple-forms edn/read-string)
+        write-str-fn (cond (and multiple? pretty?) pprint-str-multiple-forms
+                           (and multiple? (not pretty?)) prn-str-multiple-forms
+                           (and (not multiple?) pretty?) pprint-str
+                           (and (not multiple?) (not pretty?)) prn-str)]
+    (-> *in* slurp read-fn clj2el write-str-fn print)))

--- a/src/clj2el/exec.clj
+++ b/src/clj2el/exec.clj
@@ -13,4 +13,5 @@
 
 #_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
 (defn exec [_opts]
-  (->> *in* slurp read-str-multiple (map clj2el) write-str-multiple print))
+  (->> *in* slurp read-str-multiple (map clj2el) write-str-multiple print)
+  (flush))

--- a/src/clj2el/exec.clj
+++ b/src/clj2el/exec.clj
@@ -1,4 +1,4 @@
-(ns clj2el.cli
+(ns clj2el.exec
   (:require
    [clj2el.api :refer [clj2el]]
    [clojure.pprint :refer [pprint]]

--- a/src/clj2el/exec.clj
+++ b/src/clj2el/exec.clj
@@ -11,5 +11,6 @@
 (defn write-str-multiple [forms]
   (str/join "\n" (map #(with-out-str (pprint %)) forms)))
 
-(defn -main [& _args]
+#_{:clj-kondo/ignore [:clojure-lsp/unused-public-var]}
+(defn exec [_opts]
   (->> *in* slurp read-str-multiple (map clj2el) write-str-multiple print))


### PR DESCRIPTION
This PR proposes a CLI for `clj2el`. Example usage:

```
$ ls
source.clj  source2.clj
$ cat source.clj
(defn foo [x & xs] xs)

(inc 2)

(map inc [1 2 3])
$ cat source.clj | clj2el
(defun foo (x &rest xs) xs)

(1+ 2)

(mapcar #'1+ (vector 1 2 3))
$ cat source2.clj
[1 2 3]
$ cat source2.clj | clj2el
(vector 1 2 3)

```